### PR TITLE
removed ssl:// prefix in upgradeProtocol

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-	"name": "bazo/wamp-client",
+	"name": "loertel/wamp-client",
 	"type": "library",
 	"description": "WAMP client in PHP",
 	"keywords": ["Ratchet", "WAMP", "WebSocket"],
 	"license": "MIT",
 	"authors": [
 		{
-			"name": "Martin Bažík",
+			"name": "Martin Bažík (loertel fork)",
 			"email": "martin@bazo.sk"
 		}
 	],

--- a/src/WAMP/WAMPClient.php
+++ b/src/WAMP/WAMPClient.php
@@ -76,8 +76,10 @@ class WAMPClient
             throw new \RuntimeException('Wamp Server Target is wrong.');
         }
 
+
+        $host = str_replace('ssl://', '', $this->serverHost);
         $out = "GET ".$target." HTTP/1.1\r\n";
-        $out .= "Host: {$this->serverHost} \r\n";
+        $out .= "Host: {$host} \r\n";
 		$out .= "Upgrade: WebSocket\r\n";
 		$out .= "Connection: Upgrade\r\n";
 		$out .= "Sec-WebSocket-Key: $key \r\n";


### PR DESCRIPTION
removed ssl:// prefix in upgradeProtocol cause nginx throws http 400

If using an SSL connection proxied through nginx - nginx throws a 400 while trying to upgrade connection - in request headerline: 
host: "ssl://XXXXXX"  

Original nginx error message:
client sent invalid host header while reading client request headers,
client: 127.0.0.1, server: lo-dev, request: "GET
/publicchat/d8451499d04a39c5feef9c11d13f3f4916c6488d/29223 HTTP/1.1",
host: "ssl://lo-dev"
